### PR TITLE
ci(github): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Each line is a file pattern followed by one or more owners.
+# Patterns match paths relative to the repo root.
+# Later matches take precedence over earlier ones.
+# See: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customizations/about-code-owners
+
+* @somnio-kimm


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` so review assignment is automatic.

## Changes
- Add `.github/CODEOWNERS` (default owner `@somnio-kimm`)

## Related Issue
Closes #3

## Notes
-

## Test
N/A