### PR TITLE
ci(github): add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/mobile"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      mobile-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Weekly dependabot bumps for GitHub Actions and both npm package trees (root + `mobile/`).

## Changes
- Add `.github/dependabot.yml`

## Related Issue
Closes #4

## Notes
- Two npm ecosystems because root and `mobile/` will have separate `package.json` trees.

## Test
N/A