### PR TITLE
ci(github): add claude-review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,50 @@
+name: Claude Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  issue_comment:
+    types:
+      - created
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: read
+  id-token: write
+
+jobs:
+  claude-review:
+    if: >
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@claude') &&
+        github.event.comment.user.type != 'Bot')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review according to REVIEW.md and CLAUDE.md.
+            Write the review in English.
+            If there are no meaningful findings, say that clearly.
+          claude_args: |
+            --max-turns 64
+            --model claude-opus-4-6


### PR DESCRIPTION
## Summary
- Run Claude on every non-draft PR and on `@claude` comments, per `REVIEW.md` and `CLAUDE.md`.

## Changes
- Add `.github/workflows/claude-review.yml`

## Related Issue
Closes #6

## Notes
- Requires `CLAUDE_CODE_OAUTH_TOKEN` repo secret.

## Test
N/A (will exercise on next PR)