### PR TITLE
chore(repo): extend .gitignore and add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{swift,kt,java}]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -27,16 +27,42 @@ Pods/
 
 # Secrets
 .env
+.env.*
+!.env.example
 
 # Node
 node_modules/
 mobile/node_modules/
 npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.npm/
+.pnpm-store/
+
+# Build output
+dist/
+.cache/
+.parcel-cache/
+coverage/
 
 # Capacitor / native builds
 mobile/android/.gradle/
 mobile/android/.idea/
 mobile/android/build/
 mobile/android/app/build/
+mobile/android/local.properties
 mobile/ios/App/App.xcworkspace/
 mobile/ios/App/App.xcuserdata/
+mobile/ios/App/Pods/
+
+# IDE
+.idea/
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
+!.vscode/tasks.json
+!.vscode/launch.json
+
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- Extend `.gitignore` with common Node/build/native patterns and add `.editorconfig`.

## Changes
- Extend `.gitignore` (env, logs, dist/cache, Android local.properties, iOS Pods, selective .vscode passthrough)
- Add `.editorconfig` (2-space default; 4-space for Swift/Kotlin/Java; tabs for Makefile; preserve trailing whitespace in Markdown)

## Related Issue
Closes #14

## Notes
- `.vscode/` allowlist mirrors `learn_chinese`'s.

## Test
N/A