### PR TITLE
feat(data): add data schema docs and seed files

### DIFF
--- a/data/augment.json
+++ b/data/augment.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "notes": "Top-level overrides. Per-POS arrays live in data/augment/parts/<pos>/*.json."
+}

--- a/data/augment/parts/adjectives/a1.json
+++ b/data/augment/parts/adjectives/a1.json
@@ -1,0 +1,34 @@
+[
+  {
+    "lemma": "groß",
+    "pos": "adjective",
+    "cefr": "A1",
+    "meaning_en": ["big", "tall"],
+    "examples": [
+      { "de": "Das Haus ist groß.", "en": "The house is big." }
+    ],
+    "frequency_rank": 88,
+    "notes": null,
+    "source": "manual-augment",
+    "comparative": "größer",
+    "superlative": "am größten",
+    "predicative_only": false,
+    "declension_notes": null
+  },
+  {
+    "lemma": "klein",
+    "pos": "adjective",
+    "cefr": "A1",
+    "meaning_en": ["small", "little"],
+    "examples": [
+      { "de": "Der Hund ist klein.", "en": "The dog is small." }
+    ],
+    "frequency_rank": 145,
+    "notes": null,
+    "source": "manual-augment",
+    "comparative": "kleiner",
+    "superlative": "am kleinsten",
+    "predicative_only": false,
+    "declension_notes": null
+  }
+]

--- a/data/augment/parts/functional/a1.json
+++ b/data/augment/parts/functional/a1.json
@@ -1,0 +1,33 @@
+[
+  {
+    "lemma": "in",
+    "pos": "functional",
+    "cefr": "A1",
+    "meaning_en": ["in", "into"],
+    "examples": [
+      { "de": "Ich bin in der Schule.", "en": "I'm at school." },
+      { "de": "Ich gehe in die Schule.", "en": "I'm going to school." }
+    ],
+    "frequency_rank": 7,
+    "notes": "Two-way preposition: dative for location, accusative for direction.",
+    "source": "manual-augment",
+    "subtype": "preposition",
+    "case": ["dat", "acc"],
+    "governs": null
+  },
+  {
+    "lemma": "und",
+    "pos": "functional",
+    "cefr": "A1",
+    "meaning_en": ["and"],
+    "examples": [
+      { "de": "Brot und Butter.", "en": "Bread and butter." }
+    ],
+    "frequency_rank": 4,
+    "notes": "Coordinating conjunction; does not change word order.",
+    "source": "manual-augment",
+    "subtype": "conjunction",
+    "case": null,
+    "governs": "coordinating"
+  }
+]

--- a/data/augment/parts/nouns/a1.json
+++ b/data/augment/parts/nouns/a1.json
@@ -1,0 +1,65 @@
+[
+  {
+    "lemma": "Haus",
+    "pos": "noun",
+    "cefr": "A1",
+    "meaning_en": ["house", "home"],
+    "examples": [
+      { "de": "Das Haus ist groß.", "en": "The house is big." }
+    ],
+    "frequency_rank": 134,
+    "notes": null,
+    "source": "manual-augment",
+    "article": "das",
+    "gender": "neuter",
+    "plural": "Häuser",
+    "declension": {
+      "nom": ["das Haus", "die Häuser"],
+      "acc": ["das Haus", "die Häuser"],
+      "dat": ["dem Haus(e)", "den Häusern"],
+      "gen": ["des Hauses", "der Häuser"]
+    }
+  },
+  {
+    "lemma": "Frau",
+    "pos": "noun",
+    "cefr": "A1",
+    "meaning_en": ["woman", "Mrs."],
+    "examples": [
+      { "de": "Die Frau heißt Anna.", "en": "The woman's name is Anna." }
+    ],
+    "frequency_rank": 211,
+    "notes": null,
+    "source": "manual-augment",
+    "article": "die",
+    "gender": "feminine",
+    "plural": "Frauen",
+    "declension": {
+      "nom": ["die Frau", "die Frauen"],
+      "acc": ["die Frau", "die Frauen"],
+      "dat": ["der Frau", "den Frauen"],
+      "gen": ["der Frau", "der Frauen"]
+    }
+  },
+  {
+    "lemma": "Mann",
+    "pos": "noun",
+    "cefr": "A1",
+    "meaning_en": ["man", "husband"],
+    "examples": [
+      { "de": "Der Mann ist müde.", "en": "The man is tired." }
+    ],
+    "frequency_rank": 198,
+    "notes": null,
+    "source": "manual-augment",
+    "article": "der",
+    "gender": "masculine",
+    "plural": "Männer",
+    "declension": {
+      "nom": ["der Mann", "die Männer"],
+      "acc": ["den Mann", "die Männer"],
+      "dat": ["dem Mann(e)", "den Männern"],
+      "gen": ["des Mannes", "der Männer"]
+    }
+  }
+]

--- a/data/augment/parts/verbs/a1.json
+++ b/data/augment/parts/verbs/a1.json
@@ -1,0 +1,48 @@
+[
+  {
+    "lemma": "gehen",
+    "pos": "verb",
+    "cefr": "A1",
+    "meaning_en": ["to go", "to walk"],
+    "examples": [
+      { "de": "Ich gehe nach Hause.", "en": "I'm going home." }
+    ],
+    "frequency_rank": 42,
+    "notes": null,
+    "source": "manual-augment",
+    "infinitive": "gehen",
+    "class": "strong",
+    "separable_prefix": null,
+    "auxiliary": "sein",
+    "stems": { "present": "geh", "preterite": "ging", "participle": "gegangen" },
+    "forms": {
+      "praesens": { "ich": "gehe", "du": "gehst", "er": "geht", "wir": "gehen", "ihr": "geht", "sie": "gehen" },
+      "praeteritum": { "ich": "ging", "du": "gingst", "er": "ging", "wir": "gingen", "ihr": "gingt", "sie": "gingen" },
+      "perfekt": "ist gegangen",
+      "konjunktiv_ii": { "ich": "ginge", "du": "gingest", "er": "ginge", "wir": "gingen", "ihr": "ginget", "sie": "gingen" }
+    }
+  },
+  {
+    "lemma": "machen",
+    "pos": "verb",
+    "cefr": "A1",
+    "meaning_en": ["to do", "to make"],
+    "examples": [
+      { "de": "Was machst du?", "en": "What are you doing?" }
+    ],
+    "frequency_rank": 31,
+    "notes": null,
+    "source": "manual-augment",
+    "infinitive": "machen",
+    "class": "weak",
+    "separable_prefix": null,
+    "auxiliary": "haben",
+    "stems": { "present": "mach", "preterite": "machte", "participle": "gemacht" },
+    "forms": {
+      "praesens": { "ich": "mache", "du": "machst", "er": "macht", "wir": "machen", "ihr": "macht", "sie": "machen" },
+      "praeteritum": { "ich": "machte", "du": "machtest", "er": "machte", "wir": "machten", "ihr": "machtet", "sie": "machten" },
+      "perfekt": "hat gemacht",
+      "konjunktiv_ii": { "ich": "machte", "du": "machtest", "er": "machte", "wir": "machten", "ihr": "machtet", "sie": "machten" }
+    }
+  }
+]

--- a/data/schema.md
+++ b/data/schema.md
@@ -1,0 +1,83 @@
+# Data Schema
+
+Every entry in `data/augment/parts/<pos>/*.json` and the generated
+`web/data/cefr-<level>/<pos>.json` files shares an envelope and adds
+POS-specific fields. The envelope and POS contracts are versioned
+via the top-level `schema_version` in `web/data/index.json`.
+
+## Shared envelope
+
+| Field            | Type                                  | Notes                                                                                  |
+| ---------------- | ------------------------------------- | -------------------------------------------------------------------------------------- |
+| `lemma`          | string                                | Citation form, German orthography. Nouns are capitalized.                              |
+| `pos`            | `"noun" \| "verb" \| "adjective" \| "functional"` | Drives which extra fields are required.                                    |
+| `cefr`           | `"A1" \| "A2" \| "B1" \| "B2" \| "C1" \| "C2"` | Level bucket for filtering / lazy loading.                                |
+| `meaning_en`     | string[]                              | Short English glosses, one or more.                                                    |
+| `examples`       | `{ de: string, en: string }[]`        | Optional; recommended at least one.                                                    |
+| `frequency_rank` | number \| null                        | Lower = more frequent. Used to weight spaced-repetition scheduling.                    |
+| `notes`          | string \| null                        | Free-form note (false friends, register, etc.).                                        |
+| `source`         | string                                | Provenance tag (e.g. `goethe-a1`, `wiktionary`, `manual-augment`).                     |
+
+## POS-specific fields
+
+### `pos: "noun"`
+
+| Field          | Type                                                                                  | Notes                                                                |
+| -------------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `article`      | `"der" \| "die" \| "das"`                                                             | Definite article in nominative singular.                             |
+| `gender`       | `"masculine" \| "feminine" \| "neuter"`                                               | Redundant with `article` but explicit for filtering and color cues.  |
+| `plural`       | string \| null                                                                        | Nominative plural; `null` for *Singularetantum*.                     |
+| `declension`   | `{ nom: [sg, pl], acc: [sg, pl], dat: [sg, pl], gen: [sg, pl] }`                      | Forms include the article (`das Haus`, `dem Haus(e)`).               |
+
+### `pos: "verb"`
+
+| Field              | Type                                                                                            | Notes                                                                                |
+| ------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `infinitive`       | string                                                                                          | Same as `lemma` for verbs.                                                           |
+| `class`            | `"strong" \| "weak" \| "mixed" \| "modal" \| "separable" \| "irregular"`                        | Drives conjugator strategy.                                                          |
+| `separable_prefix` | string \| null                                                                                  | e.g. `"ab"` for `abfahren`.                                                          |
+| `auxiliary`        | `"haben" \| "sein"`                                                                             | For Perfekt construction.                                                            |
+| `stems`            | `{ present: string, preterite: string, participle: string }`                                    | Used by the conjugator and the conjugation-drill view.                               |
+| `forms`            | `{ praesens: PersonForms, praeteritum: PersonForms, perfekt: string, konjunktiv_ii: PersonForms }` | `PersonForms = { ich, du, er, wir, ihr, sie }`. `perfekt` is the canonical 3rd-sg. |
+
+### `pos: "adjective"`
+
+| Field               | Type            | Notes                                              |
+| ------------------- | --------------- | -------------------------------------------------- |
+| `comparative`       | string \| null  | e.g. `"größer"`. `null` if not gradable.           |
+| `superlative`       | string \| null  | e.g. `"am größten"`.                               |
+| `predicative_only`  | boolean         | `true` for `egal`, `schade`, etc.                  |
+| `declension_notes`  | string \| null  | Free-form note about strong/mixed/weak endings.    |
+
+### `pos: "functional"`
+
+| Field      | Type                                                                                                | Notes                                                          |
+| ---------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `subtype`  | `"pronoun" \| "preposition" \| "article" \| "conjunction" \| "particle" \| "adverb"`                | Discriminator for views that handle pronouns vs prepositions.  |
+| `case`     | `("nom" \| "acc" \| "dat" \| "gen")[]` \| null                                                      | For prepositions: cases governed (`["dat", "acc"]` for *in*).  |
+| `governs`  | string \| null                                                                                      | For subordinating conjunctions: usage hint.                    |
+
+## Augment files
+
+Files under `data/augment/parts/<pos>/*.json` are the **manual source of truth**. The
+build pipeline reads these, applies the weak-verb conjugator stub for entries
+that omit `forms`, and emits sharded JSON under `web/data/cefr-<level>/<pos>.json`.
+
+Each augment file is a JSON array of entries.
+
+## Index manifest
+
+`web/data/index.json` is generated by `sync-web-data.mjs`:
+
+```jsonc
+{
+  "schema_version": 1,
+  "generated_at": "2026-04-25T00:00:00Z",
+  "levels": {
+    "A1": { "nouns": 0, "verbs": 0, "adjectives": 0, "functional": 0 },
+    "A2": { "nouns": 0, "verbs": 0, "adjectives": 0, "functional": 0 }
+  }
+}
+```
+
+Clients read `index.json` first to decide which `cefr-<level>/<pos>.json` to fetch.


### PR DESCRIPTION
## Summary
- Define the German entry schema (shared envelope + POS-specific fields) and seed minimal A1 sample data per POS.

## Changes
- Add `data/schema.md` — full schema reference (noun, verb, adjective, functional)
- Add `data/augment.json` — top-level schema_version stub
- Add `data/augment/parts/{nouns,verbs,adjectives,functional}/a1.json` — small hand-curated A1 sample (Haus, Frau, Mann, gehen, machen, groß, klein, in, und)

## Related Issue
Closes #15

## Notes
- Augment files are the manual source of truth; the build pipeline (next PR) reads these and emits sharded `web/data/cefr-<level>/<pos>.json`.
- Index manifest `web/data/index.json` shape documented in `schema.md`; will be generated by the sync script.

## Test
N/A (data + docs)