### PR TITLE
feat(scripts): add data build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ dist/
 .parcel-cache/
 coverage/
 
+# Generated data build stages (web/data is the runtime artifact and is checked in)
+data/_built/
+data/_merged/
+
 # Capacitor / native builds
 mobile/android/.gradle/
 mobile/android/.idea/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "learn-german-tools",
+  "private": true,
+  "type": "module",
+  "description": "Dev scripts for building CEFR-leveled German vocabulary data.",
+  "scripts": {
+    "build:cefr": "node scripts/build-cefr-data.mjs",
+    "merge:augment": "node scripts/merge-augment.mjs",
+    "sync:web-data": "node scripts/sync-web-data.mjs",
+    "build:cefr:web": "npm run build:cefr && npm run merge:augment && npm run sync:web-data",
+    "mobile:sync": "npm run build:cefr:web && cd mobile && npm run sync"
+  },
+  "dependencies": {}
+}

--- a/scripts/build-cefr-data.mjs
+++ b/scripts/build-cefr-data.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Reads data/augment/parts/<pos>/*.json (the manual source of truth) and
+// writes a flat staging tree at data/_built/cefr-<level>/<pos>.json keyed
+// only by lemma. merge-augment.mjs overlays additional augment data; the
+// final web bundle is produced by sync-web-data.mjs.
+//
+// Usage: node scripts/build-cefr-data.mjs
+
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const SRC = join(ROOT, "data", "augment", "parts");
+const OUT = join(ROOT, "data", "_built");
+
+const POS_DIRS = ["nouns", "verbs", "adjectives", "functional"];
+const LEVELS = ["A1", "A2", "B1", "B2", "C1", "C2"];
+
+async function readPartFiles(pos) {
+  const dir = join(SRC, pos);
+  let names;
+  try {
+    names = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const entries = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const raw = await readFile(join(dir, name), "utf8");
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) {
+      throw new Error(`${pos}/${name}: expected JSON array, got ${typeof arr}`);
+    }
+    entries.push(...arr);
+  }
+  return entries;
+}
+
+async function main() {
+  for (const level of LEVELS) {
+    await mkdir(join(OUT, `cefr-${level.toLowerCase()}`), { recursive: true });
+  }
+
+  for (const pos of POS_DIRS) {
+    const all = await readPartFiles(pos);
+    const byLevel = new Map(LEVELS.map((l) => [l, []]));
+
+    for (const entry of all) {
+      if (!byLevel.has(entry.cefr)) {
+        throw new Error(`${entry.lemma}: unknown cefr level "${entry.cefr}"`);
+      }
+      byLevel.get(entry.cefr).push(entry);
+    }
+
+    for (const level of LEVELS) {
+      const items = byLevel.get(level);
+      const path = join(OUT, `cefr-${level.toLowerCase()}`, `${pos}.json`);
+      await writeFile(path, JSON.stringify(items, null, 2) + "\n");
+      if (items.length > 0) {
+        console.log(`built cefr-${level.toLowerCase()}/${pos}.json (${items.length} entries)`);
+      }
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/lib/verb-conjugator.mjs
+++ b/scripts/lib/verb-conjugator.mjs
@@ -1,0 +1,54 @@
+// Tiny weak-verb conjugator. Handles regular -en weak verbs only.
+// Strong, mixed, modal, and irregular verbs must supply `forms` manually
+// in their augment JSON; we warn (in merge-augment) when a weak-or-unknown
+// verb is missing forms.
+//
+// This is a stub — it does not handle:
+//   - separable prefixes (e.g. abfahren)
+//   - stems ending in -d/-t (which take Bindungs-e: arbeitest, not arbeitst)
+//   - stems ending in -s/-ß/-x/-z (du-form contraction)
+//   - any vowel change
+//
+// When you need those cases, add them to the augment JSON or extend this
+// module under its own feat PR.
+
+const PERSON_KEYS = ["ich", "du", "er", "wir", "ihr", "sie"];
+
+function presentEndings(stem) {
+  return {
+    ich: stem + "e",
+    du: stem + "st",
+    er: stem + "t",
+    wir: stem + "en",
+    ihr: stem + "t",
+    sie: stem + "en",
+  };
+}
+
+function preteriteEndings(stem) {
+  // Weak: stem + te + person ending
+  const base = stem + "te";
+  return {
+    ich: base,
+    du: base + "st",
+    er: base,
+    wir: base + "n",
+    ihr: base + "t",
+    sie: base + "n",
+  };
+}
+
+export function conjugateWeakVerb(infinitive) {
+  if (!/en$/.test(infinitive)) {
+    throw new Error(`conjugateWeakVerb: ${infinitive} does not end in -en`);
+  }
+  const stem = infinitive.replace(/en$/, "");
+  return {
+    praesens: presentEndings(stem),
+    praeteritum: preteriteEndings(stem),
+    perfekt: `hat ge${stem}t`,
+    konjunktiv_ii: preteriteEndings(stem),
+  };
+}
+
+export const _PERSON_KEYS = PERSON_KEYS;

--- a/scripts/merge-augment.mjs
+++ b/scripts/merge-augment.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Reads data/_built/cefr-<level>/<pos>.json and applies any per-entry overrides
+// from data/augment.json into a final data/_merged/ tree. Overrides are matched
+// by lemma+pos.
+//
+// For verbs, if `forms` is missing and `class === "weak"`, the weak-verb
+// conjugator stub fills it in. Other classes must supply forms manually.
+
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { conjugateWeakVerb } from "./lib/verb-conjugator.mjs";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const BUILT = join(ROOT, "data", "_built");
+const OUT = join(ROOT, "data", "_merged");
+const AUGMENT_FILE = join(ROOT, "data", "augment.json");
+
+async function loadAugmentOverrides() {
+  try {
+    const raw = await readFile(AUGMENT_FILE, "utf8");
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed.overrides) ? parsed.overrides : [];
+  } catch {
+    return [];
+  }
+}
+
+function applyOverride(entry, override) {
+  return { ...entry, ...override };
+}
+
+function fillMissingVerbForms(entry) {
+  if (entry.pos !== "verb") return entry;
+  if (entry.forms) return entry;
+  if (entry.class !== "weak") {
+    console.warn(
+      `${entry.lemma}: missing forms and class is "${entry.class}"; supply manually.`,
+    );
+    return entry;
+  }
+  return { ...entry, forms: conjugateWeakVerb(entry.infinitive ?? entry.lemma) };
+}
+
+async function main() {
+  const overrides = await loadAugmentOverrides();
+  const overrideIndex = new Map(
+    overrides.map((o) => [`${o.pos}:${o.lemma}`, o]),
+  );
+
+  let levelDirs;
+  try {
+    levelDirs = await readdir(BUILT);
+  } catch {
+    console.error(`no built tree at ${BUILT}; run build:cefr first.`);
+    process.exit(1);
+  }
+
+  for (const levelDir of levelDirs) {
+    const inDir = join(BUILT, levelDir);
+    const outDir = join(OUT, levelDir);
+    await mkdir(outDir, { recursive: true });
+
+    const files = await readdir(inDir);
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      const raw = await readFile(join(inDir, file), "utf8");
+      const items = JSON.parse(raw);
+
+      const merged = items.map((entry) => {
+        const key = `${entry.pos}:${entry.lemma}`;
+        const overridden = overrideIndex.has(key)
+          ? applyOverride(entry, overrideIndex.get(key))
+          : entry;
+        return fillMissingVerbForms(overridden);
+      });
+
+      await writeFile(join(outDir, file), JSON.stringify(merged, null, 2) + "\n");
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/sync-web-data.mjs
+++ b/scripts/sync-web-data.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Copies data/_merged/cefr-<level>/<pos>.json to web/data/<...> and emits
+// web/data/index.json with counts per level × POS.
+
+import { copyFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const MERGED = join(ROOT, "data", "_merged");
+const WEB_DATA = join(ROOT, "web", "data");
+
+const SCHEMA_VERSION = 1;
+
+function levelLabelFromDir(dir) {
+  // cefr-a1 → A1
+  return dir.replace(/^cefr-/, "").toUpperCase();
+}
+
+async function main() {
+  let levelDirs;
+  try {
+    levelDirs = await readdir(MERGED);
+  } catch {
+    console.error(`no merged tree at ${MERGED}; run merge:augment first.`);
+    process.exit(1);
+  }
+
+  const levels = {};
+
+  for (const levelDir of levelDirs) {
+    const inDir = join(MERGED, levelDir);
+    const outDir = join(WEB_DATA, levelDir);
+    await mkdir(outDir, { recursive: true });
+
+    const files = await readdir(inDir);
+    const levelLabel = levelLabelFromDir(levelDir);
+    levels[levelLabel] = {};
+
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      const src = join(inDir, file);
+      const dst = join(outDir, file);
+      await copyFile(src, dst);
+
+      const arr = JSON.parse(await readFile(src, "utf8"));
+      const pos = file.replace(/\.json$/, "");
+      levels[levelLabel][pos] = arr.length;
+    }
+  }
+
+  const index = {
+    schema_version: SCHEMA_VERSION,
+    generated_at: new Date().toISOString(),
+    levels,
+  };
+  await mkdir(WEB_DATA, { recursive: true });
+  await writeFile(join(WEB_DATA, "index.json"), JSON.stringify(index, null, 2) + "\n");
+  console.log(`wrote ${join("web", "data", "index.json")}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add the 3-stage data build pipeline (build → merge-augment → sync-web-data) and a weak-verb conjugator stub.

## Changes
- Add `package.json` with scripts: `build:cefr`, `merge:augment`, `sync:web-data`, `build:cefr:web`, `mobile:sync`
- Add `scripts/build-cefr-data.mjs` — reads `data/augment/parts/<pos>/*.json` and emits per-level/per-POS JSON to `data/_built/`
- Add `scripts/merge-augment.mjs` — applies overrides from `data/augment.json`, fills missing weak-verb forms via the conjugator
- Add `scripts/sync-web-data.mjs` — copies merged tree into `web/data/` and emits `web/data/index.json` (counts per level × POS)
- Add `scripts/lib/verb-conjugator.mjs` — minimal weak-verb conjugator (regular -en only). Strong/mixed/modal/separable verbs must supply `forms` manually
- Extend `.gitignore` to ignore `data/_built/` and `data/_merged/` (generated staging trees)

## Related Issue
Closes #16

## Notes
- Verified end-to-end with the seed data from #15: produces `web/data/cefr-a1/{nouns,verbs,adjectives,functional}.json` and a populated `index.json`.
- The conjugator is intentionally minimal; it does NOT handle separable prefixes, -d/-t Bindungs-e, du-form contractions, or vowel changes. Extend in a separate feat PR when needed.

## Test
`npm run build:cefr:web` — produced expected output locally during development.