### PR TITLE
feat(mobile): add Capacitor wrapper stub

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,36 @@
+# Mobile (Capacitor)
+
+This directory wraps the `web/` PWA as native iOS and Android apps via Capacitor.
+
+## First-time setup
+
+The native projects (`ios/`, `android/`) are **not** committed initially —
+they are large, toolchain-dependent, and Capacitor regenerates them
+deterministically. Run these once locally:
+
+```bash
+cd mobile
+npm install
+npm run add:ios       # creates mobile/ios/
+npm run add:android   # creates mobile/android/
+```
+
+Then commit the generated projects in a follow-up PR scoped to whichever
+platform you set up first (e.g. `feat/<n>-ios-project` / `feat/<n>-android-project`).
+
+## Sync the web bundle
+
+Whenever `web/` changes:
+
+```bash
+npm run sync
+```
+
+This copies `../web/` into the platform-specific webview asset folders.
+
+## Open in IDE
+
+```bash
+npm run open:ios       # opens Xcode
+npm run open:android   # opens Android Studio
+```

--- a/mobile/capacitor.config.json
+++ b/mobile/capacitor.config.json
@@ -1,0 +1,12 @@
+{
+  "appId": "com.somniokimm.learn_german",
+  "appName": "learn_german",
+  "webDir": "../web",
+  "bundledWebRuntime": false,
+  "ios": {
+    "scheme": "learn_german"
+  },
+  "android": {
+    "buildOptions": {}
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "learn-german-mobile",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Capacitor wrapper that ships the web/ codebase as iOS and Android apps.",
+  "scripts": {
+    "sync": "cap sync",
+    "open:ios": "cap open ios",
+    "open:android": "cap open android",
+    "add:ios": "cap add ios",
+    "add:android": "cap add android"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^7.0.0"
+  },
+  "dependencies": {
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
+    "@capacitor/ios": "^7.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Add the Capacitor wrapper config so native iOS/Android projects can be generated and the `web/` bundle synced into them.

## Changes
- Add `mobile/package.json` — Capacitor 7 deps (`@capacitor/{cli,core,ios,android}`) and scripts (`sync`, `open:ios`, `open:android`, `add:ios`, `add:android`)
- Add `mobile/capacitor.config.json` — appId `com.somniokimm.learn_german`, points `webDir` at `../web`
- Add `mobile/README.md` — first-time `cap add` instructions and sync flow

## Related Issue
Closes #18

## Notes
- `mobile/ios/` and `mobile/android/` are NOT committed in this PR. They are toolchain-dependent and Capacitor regenerates them deterministically — run `npm run add:ios` / `npm run add:android` locally, then commit via separate PRs (or leave them gitignored if you prefer rebuild-on-demand).
- `webDir` is `../web` so Capacitor sees the existing PWA at the repo root without duplicating files.

## Test
N/A (no native project generated here). Verify with `cd mobile && npm install && npm run add:ios` locally.