### PR TITLE
chore(tooling): add .vscode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  "editor.formatOnSave": false,
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  },
+  "files.exclude": {
+    "**/node_modules": true,
+    "data/_built": true,
+    "data/_merged": true
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "data/_built": true,
+    "data/_merged": true,
+    "package-lock.json": true,
+    "mobile/package-lock.json": true
+  }
+}


### PR DESCRIPTION
## Summary
- Add curated workspace settings (per the `.gitignore` allowlist added in #14): consistent indentation, EOL, final-newline, and exclusion of generated build trees from file tree and search.

## Changes
- Add `.vscode/settings.json` (force-added because the user's global ignore covers `.vscode/`)

## Related Issue
Closes #19

## Notes
- `files.exclude` and `search.exclude` skip `data/_built` and `data/_merged` (the staging trees from `build:cefr` and `merge:augment`) so they don't pollute the editor file tree.
- Markdown files preserve trailing whitespace (matches `.editorconfig`).

## Test
N/A